### PR TITLE
check if node is in dev or prod mode before injecting hubspot code

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -16,11 +16,13 @@ export const wrapPageElement = ({ element, props }) => {
 export function onRenderBody(
   { setHeadComponents }
 ) {
- setHeadComponents([
-     <script
-        key="hubspot"
-        type="text/javascript"
-        src="//js.hs-scripts.com/6342968.js"
-      />,
-  ]);
+  if (process.env.NODE_ENV !== 'development') {
+    setHeadComponents([
+       <script
+          key="hubspot"
+          type="text/javascript"
+          src="//js.hs-scripts.com/6342968.js"
+        />,
+    ]);
+  }
 }


### PR DESCRIPTION
while doing the other requests, i noticed in the console that hubspot fires of a zillion requests, which is probably totally unnecessary in development mode.

i added a check in gatsby-ssr.js to see if node is running in dev mode before injecting the hubspot javascript.