### PR TITLE
add gatsby image fragment to graphql query

### DIFF
--- a/src/hooks/use-capabilities.js
+++ b/src/hooks/use-capabilities.js
@@ -10,18 +10,7 @@ const capailitiesQuery = graphql`
                         icon {
                             childImageSharp {
                                 fluid(maxWidth: 100) {
-                                    base64
-                                    tracedSVG
-                                    aspectRatio
-                                    src
-                                    srcSet
-                                    srcWebp
-                                    srcSetWebp
-                                    sizes
-                                    originalImg
-                                    originalName
-                                    presentationWidth
-                                    presentationHeight
+                                    ...GatsbyImageSharpFluid
                                 }
                             }
                         }


### PR DESCRIPTION
i was getting a warning stemming from a field `aspectRatio` that is used in a graphql query in the use-capabilities hook. i guessed that the fields that were hard-coded change over time, and using a graphql fragment that Gatsby builds in (`GatsbyImageSharpFluid`) would eliminate this warning.

do you get any image or graphql warnings in the console after a `gatsby clean`?