### PR TITLE
Enhancement/112 116 119 add code sign

### DIFF
--- a/src/data/events/2021-06-09_nitrd-team-meeting.md
+++ b/src/data/events/2021-06-09_nitrd-team-meeting.md
@@ -7,6 +7,8 @@ location: Virtual
 url: https://internet2.edu/internet2-community-voices-series/
 tags: ["NITRD", "Ilya Baldin"]
 fabricHosted: false
+presenter: Ilya Baldin
+presentation_link: ""
 seo:
   title: NITRD Advanced Wireless Test Platform Team Meeting
   description: FABRIC leadership team member Ilya Baldin will speak to the NITRD's Advanced Wireless Test Platform Team at 3 p.m. ET.

--- a/src/data/events/2021-06-18_US-networking-workshop-for-open-call-4.md
+++ b/src/data/events/2021-06-18_US-networking-workshop-for-open-call-4.md
@@ -1,0 +1,18 @@
+---
+title: NGIatlantic.eu – NSF EU – US Networking workshop for Open call 4
+path: /events/US-networking-workshop-for-open-call-4
+date: 2021-06-18
+display_date: June 18, 2021
+location: Virtual
+url: https://ngiatlantic.eu/events/ngiatlanticeu-nsf-eu-us-networking-workshop-open-call-4
+tags: ["workshop", "Anita Nikolich"]
+fabricHosted: false
+presenter: Anita Nikolich
+presentation_link: ""
+seo:
+  title: NITRD Advanced Wireless Test Platform Team Meeting
+  description: FABRIC leadership team member Anita Nikolich will speak on FABRIC internationalization activities and the connectivity of EU platforms with FABRIC nodes coming on-stream in Q3 2021 at 11:15 a.m. ET.
+  keywords: ["workshop", "Anita Nikolich"]
+---
+
+FABRIC leadership team member Anita Nikolich will speak on FABRIC internationalization activities and the connectivity of EU platforms with FABRIC nodes coming on-stream in Q3 2021 at 11:15 a.m. ET.

--- a/src/data/news/2021-07-07_trusted-CI-concludes-engagement-with-FABRIC/index.md
+++ b/src/data/news/2021-07-07_trusted-CI-concludes-engagement-with-FABRIC/index.md
@@ -1,0 +1,21 @@
+---
+path: /news/trusted-CI-concludes-engagement-with-FABRIC
+date: 2021-07-07
+title: "Trusted CI Concludes Engagement with FABRIC"
+subtitle:
+tags: ["Trusted CI"]
+seo:
+  title: "Trusted CI Concludes Engagement with FABRIC"
+  description: "The five-month engagement began in February and completed in June. In that time the teams worked together to review FABRIC’s project documentation, which included a deep analysis of the security architecture."
+  keywords: ["Trusted CI"]
+---
+
+<i>This article was originally published on the <a href="https://blog.trustedci.org/2021/07/FABRIC-engagement-ends.html" target="_blank" rel="noopener noreferrer">Trusted CI website</a></i>.
+
+FABRIC: Adaptive Programmable Research Infrastructure for Computer Science and Science Applications, funded under NSF grants <a href="https://nsf.gov/awardsearch/showAward?AWD_ID=1935966" target="_blank" rel="noopener noreferrer">1935966</a> and <a href="https://nsf.gov/awardsearch/showAward?AWD_ID=2029261" target="_blank" rel="noopener noreferrer">2029261</a>, is a national scale testbed that connects to existing NSF testbeds (e.g., PAWR), as well as NSF Clouds (e.g., Chameleon and CloudLab), HPC Facilities, and the real Internet. FABRIC aims to expand its outreach, enabling new science applications, using a diverse array of networks, integrating machine learning, and preparing the next generation of computer science researchers.
+
+FABRIC received its initial funding in 2019 and is projected to go into operational phase in September of 2023. FABRIC reached out to Trusted CI to request a review of its software development process, the trust boundaries in the FABRIC system, and the FABRIC security and monitoring architecture.
+
+The five-month engagement began in February and completed in June. In that time the teams worked together to review FABRIC’s project documentation, which included a deep analysis of the security architecture. We moved on to completing an asset inventory and risk assessment, covering over 70 project assets, identifying attack surfaces and potential threats, and documenting current and planned security controls. Lastly, we documented engagement findings in an internal report shared with FABRIC project leadership.
+
+FABRIC also assisted with the Trusted CI 2021 Annual Challenge (<a href="https://blog.trustedci.org/2021/03/announcing-2021-trusted-ci-annual.html" target="_blank" rel="noopener noreferrer">Software Assurance</a>) by participating in an interview with members of the software assurance team. The results of that interview will provide input to Trusted CI's forthcoming guide on software assurance for NSF projects.

--- a/src/templates/events/event-template.js
+++ b/src/templates/events/event-template.js
@@ -30,6 +30,8 @@ export default ({ data, pageContext }) => {
     url,
     urlLabel,
     fabricHosted,
+    presenter,
+    presentation_link,
     seo,
   } = frontmatter
 
@@ -67,6 +69,23 @@ export default ({ data, pageContext }) => {
                 </a>
               </Meta>
             )}
+            {
+              presenter && (
+                <Meta>
+                <b>Presenter</b>:{" "} {presenter}
+                </Meta>
+              )
+            }
+            {
+              presentation_link && (
+                <Meta>
+                <b>Presentation Link</b>:{" "}
+                <a href={presentation_link} target="_blank" rel="noreferrer noopener">
+                  {presentation_link}
+                </a>
+                </Meta>
+              )
+            }
             <Meta>
               <InlineList
                 title="Tags"
@@ -142,6 +161,8 @@ export const newsItemQuery = graphql`
         url
         tags
         fabricHosted
+        presenter
+        presentation_link
         seo {
           title
           description


### PR DESCRIPTION
- Issue 112: updated event template to include optional fields "presenter" and "presentation link";
- Issue 116: added the event for "US Networking workshop for Open call 4";
- Issue 119: added the news article for "Trusted CI Concludes Engagement with FABRIC".