### PR TITLE
link events menu item to events on learn.fabric-testbed.net

### DIFF
--- a/src/data/menu.js
+++ b/src/data/menu.js
@@ -1,84 +1,84 @@
 module.exports = [
-    {
-        text: 'About',
-        path: '/about',
-        submenu: [
-            {
-                text: 'Overview',
-                path: '/about/overview',
-                isExternalLink: false,
-            },
-            {
-                text: 'FAB',
-                path: '/about/fab',
-                isExternalLink: false,
-            },
-            {
-                text: 'SAC',
-                path: '/about/scientific-advisory-committee',
-                isExternalLink: false,
-            },
-            {
-                text: 'Leadership',
-                path: '/about/leadership',
-                isExternalLink: false,
-            },
-        ],
-    },
-    {
-        text: 'Resources',
-        path: '/resources',
-        submenu: [
-            {
-              text: 'Knowledge Base',
-              path: 'https://learn.fabric-testbed.net/',
-              isExternalLink: true,
-            },
-            {
-              text: 'Publications',
-              path: '/resources/publications',
-              isExternalLink: false,
-            },
-            {
-              text: 'Brochures',
-              path: '/resources/brochures',
-              isExternalLink: false,
-            },
-            {
-              text: 'Testbeds',
-              path: '/resources/testbeds',
-              isExternalLink: false,
-            },
-        ],
-    },
-    {
-        text: 'News',
-        path: '/news',
+  {
+    text: 'About',
+    path: '/about',
+    submenu: [
+      {
+        text: 'Overview',
+        path: '/about/overview',
         isExternalLink: false,
-    },
-    {
-        text: 'Events',
-        path: '/events',
+      },
+      {
+        text: 'FAB',
+        path: '/about/fab',
         isExternalLink: false,
-    },
-    {
-        text: 'Get Involved',
-        path: '/get-involved/funding-opportunities',
-        submenu: [
-          {
-              text: 'Newsletter Signup',
-              path: '/get-involved/newsletter-signup',
-              isExternalLink: false,
-          },
-          {
-              text: 'Funding Opportunities',
-              path: '/get-involved/funding-opportunities',
-              isExternalLink: false,
-          },
-      ],
+      },
+      {
+        text: 'SAC',
+        path: '/about/scientific-advisory-committee',
+        isExternalLink: false,
+      },
+      {
+        text: 'Leadership',
+        path: '/about/leadership',
+        isExternalLink: false,
+      },
+    ],
   },
   {
-      text: 'Login/Signup',
-      path: 'https://portal.fabric-testbed.net/',
+    text: 'Resources',
+    path: '/resources',
+    submenu: [
+      {
+        text: 'Knowledge Base',
+        path: 'https://learn.fabric-testbed.net/',
+        isExternalLink: true,
+      },
+      {
+        text: 'Publications',
+        path: '/resources/publications',
+        isExternalLink: false,
+      },
+      {
+        text: 'Brochures',
+        path: '/resources/brochures',
+        isExternalLink: false,
+      },
+      {
+        text: 'Testbeds',
+        path: '/resources/testbeds',
+        isExternalLink: false,
+      },
+    ],
+  },
+  {
+    text: 'News',
+    path: '/news',
+    isExternalLink: false,
+  },
+  {
+    text: 'Get Involved',
+    path: '/get-involved/funding-opportunities',
+    submenu: [
+      {
+        text: 'Newsletter Signup',
+        path: '/get-involved/newsletter-signup',
+        isExternalLink: false,
+      },
+      {
+        text: 'Funding Opportunities',
+        path: '/get-involved/funding-opportunities',
+        isExternalLink: false,
+      },
+    ],
+  },
+  {
+    text: 'Events',
+    path: 'https://learn.fabric-testbed.net/article-categories/events/',
+    isExternalLink: true,
+  },
+  {
+    text: 'Login/Signup',
+    path: 'https://portal.fabric-testbed.net/',
   },
 ]


### PR DESCRIPTION
this PR changes the behavior of the "Events" menu item. namely, it will now link to an external site, https://learn.fabric-testbed.net/article-categories/events/.

this means we can disconnect our existing events functionality, but--for the sake of getting this link change rolled out quickly--this can be completed at a later time.